### PR TITLE
Remove django-rename-app.

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -64,7 +64,6 @@ INSTALLED_APPS = [
     "import_export",
     "template_partials",
     "invitations",
-    "django_rename_app",
     # Local
     "apps.publish_mdm",
     "apps.mdm",

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,7 +9,6 @@ done
 >&2 echo "Postgres is up - continuing"
 
 if [ "x$DJANGO_MANAGEPY_MIGRATE" = 'xon' ]; then
-    python manage.py rename_app odk_publish publish_mdm
     >&2 echo "Running Migrations"
     python manage.py migrate --noinput
 fi

--- a/requirements/base/base.in
+++ b/requirements/base/base.in
@@ -12,7 +12,6 @@ django-filter
 django-htmx
 django-import-export[xls, xlsx]
 django-invitations
-django-rename-app
 django-storages
 django-structlog[celery]
 django-tables2

--- a/requirements/base/base.txt
+++ b/requirements/base/base.txt
@@ -40,9 +40,9 @@ beautifulsoup4==4.13.4
     # via -r requirements/base/base.in
 billiard==4.2.1
     # via celery
-boto3==1.38.15
+boto3==1.38.16
     # via -r requirements/base/base.in
-botocore==1.38.15
+botocore==1.38.16
     # via
     #   boto3
     #   s3transfer
@@ -126,7 +126,6 @@ django==5.2.1
     #   django-htmx
     #   django-import-export
     #   django-invitations
-    #   django-rename-app
     #   django-storages
     #   django-structlog
     #   django-tables2
@@ -148,8 +147,6 @@ django-invitations==2.1.0
     # via -r requirements/base/base.in
 django-ipware==7.0.1
     # via django-structlog
-django-rename-app==0.1.7
-    # via -r requirements/base/base.in
 django-storages==1.14.6
     # via -r requirements/base/base.in
 django-structlog==9.1.1
@@ -191,6 +188,8 @@ graphql-core==3.2.4
     #   graphql-relay
 graphql-relay==3.2.0
     # via graphene
+greenlet==3.2.2
+    # via sqlalchemy
 grpcio==1.71.0
     # via
     #   dagster

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -10,8 +10,6 @@ anyio==3.7.1
     #   httpx
     #   jupyter-server
     #   watchfiles
-appnope==0.1.4
-    # via ipykernel
 argon2-cffi==23.1.0
     # via jupyter-server
 argon2-cffi-bindings==21.2.0
@@ -42,11 +40,11 @@ black==25.1.0
     # via -r requirements/dev/dev.in
 bleach==6.2.0
     # via nbconvert
-boto3==1.38.15
+boto3==1.38.16
     # via
     #   -c requirements/dev/../base/base.txt
     #   moto
-botocore==1.38.15
+botocore==1.38.16
     # via
     #   -c requirements/dev/../base/base.txt
     #   boto3


### PR DESCRIPTION
This PR removes `django-rename-app` which is no longer needed.