### PR TITLE
Add a 'Sync from MDM' button in the Devices list page.

### DIFF
--- a/config/templates/includes/messages.html
+++ b/config/templates/includes/messages.html
@@ -1,8 +1,8 @@
 {% if messages %}
-    <section class="py-2 md:py-4">
+    <section class="py-2 md:py-4 hidden has-[.alert:not(.hidden)]:block">
         {% for message in messages %}
-            <div id="alert-{{ forloop.counter }}"
-                 class="flex items-center p-4 mb-4 rounded-lg {% if message.tags == 'info' or message.tags == 'success' %}text-primary-700 bg-primary-100 dark:bg-gray-800 dark:text-primary-300{% else %} text-red bg-red-50 dark:bg-gray-800 dark:text-red-400{% endif %}"
+            <div id="{{ id_prefix|default:'alert' }}-{{ forloop.counter }}"
+                 class="alert flex items-center p-4 mb-4 rounded-lg {% if message.tags == 'info' or message.tags == 'success' %}text-primary-700 bg-primary-100 dark:bg-gray-800 dark:text-primary-300{% else %} text-red bg-red-50 dark:bg-gray-800 dark:text-red-400{% endif %}"
                  role="alert">
                 <svg class="flex-shrink-0 w-4 h-4 dark:text-gray-300"
                      aria-hidden="true"
@@ -15,7 +15,7 @@
                 <div class="ms-3 text-sm font-medium">{{ message }}</div>
                 <button type="button"
                         class="ms-auto -mx-1.5 -my-1.5 bg-gray-50 text-gray-500 rounded-lg focus:ring-2 focus:ring-gray-400 p-1.5 hover:bg-gray-200 inline-flex items-center justify-center h-8 w-8 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white"
-                        data-dismiss-target="#alert-{{ forloop.counter }}"
+                        data-dismiss-target="#{{ id_prefix|default:'alert' }}-{{ forloop.counter }}"
                         aria-label="Close">
                     <span class="sr-only">Dismiss</span>
                     <svg class="w-3 h-3"

--- a/config/templates/publish_mdm/devices_list.html
+++ b/config/templates/publish_mdm/devices_list.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load django_tables2 %}
+{% load partials %}
 {% block extra-css %}
     <style>
     .htmx-request.loading {
@@ -8,66 +9,102 @@
     </style>
 {% endblock extra-css %}
 {% block content %}
-    <div id="inner-table">
-        {% block table-header %}
-            <div class="flex flex-col md:flex-row items-center justify-end mb-4">
-                <button type="button"
-                        class="btn btn-outline btn-primary flex items-center justify-center text-sm px-4 py-2"
-                        data-modal-target="qr-codes-modal"
-                        data-modal-toggle="qr-codes-modal">
-                    <svg class="w-[20px] h-[20px] mr-2"
-                         aria-hidden="true"
-                         xmlns="http://www.w3.org/2000/svg"
-                         width="24"
-                         height="24"
-                         fill="currentColor"
-                         viewBox="0 0 24 24">
-                        <path stroke="currentColor" stroke-linejoin="round" stroke-width="2" d="M4 4h6v6H4V4Zm10 10h6v6h-6v-6Zm0-10h6v6h-6V4Zm-4 10h.01v.01H10V14Zm0 4h.01v.01H10V18Zm-3 2h.01v.01H7V20Zm0-4h.01v.01H7V16Zm-3 2h.01v.01H4V18Zm0-4h.01v.01H4V14Z" />
-                        <path stroke="currentColor" stroke-linejoin="round" stroke-width="2" d="M7 7h.01v.01H7V7Zm10 10h.01v.01H17V17Z" />
-                    </svg>
-                    Enroll
-                </button>
-            </div>
-        {% endblock table-header %}
-        <div class="bg-white sm:rounded-md overflow-x-auto">
-            {# Progress indicator #}
-            <div class="progress">
-                <div class="indeterminate"></div>
-            </div>
-            {% render_table table %}
-        </div>
-        <div id="qr-codes-modal"
-             tabindex="-1"
-             aria-hidden="true"
-             class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full">
-            <div class="relative p-4 w-full max-w-[550px] max-h-full">
-                <div class="relative bg-white rounded-lg shadow-sm dark:bg-gray-700">
-                    <div class="flex items-center justify-between p-4 md:p-5 border-b rounded-t dark:border-gray-600 border-gray-200">
-                        <h3 class="text-xl font-semibold text-gray-900 dark:text-white">Enrollment QR codes</h3>
-                        <button type="button"
-                                class="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center dark:hover:bg-gray-600 dark:hover:text-white"
-                                data-modal-hide="qr-codes-modal">
-                            <svg class="w-3 h-3"
-                                 aria-hidden="true"
+    {% partialdef devices-list-partial inline %}
+        <div id="inner-table">
+            {% block table-header %}
+                {% include "includes/messages.html" with messages=devices_list_messages id_prefix="devices-alert" %}
+                <div class="w-full md:w-auto flex flex-col md:flex-row space-y-2 md:space-y-0 items-stretch md:items-center justify-end md:space-x-3 flex-shrink-0 mb-4">
+                    <button type="button"
+                            class="btn btn-outline btn-primary flex items-center justify-center text-sm px-4 py-2"
+                            data-modal-target="qr-codes-modal"
+                            data-modal-toggle="qr-codes-modal">
+                        <svg class="w-[20px] h-[20px] mr-2"
+                             aria-hidden="true"
+                             xmlns="http://www.w3.org/2000/svg"
+                             width="24"
+                             height="24"
+                             fill="currentColor"
+                             viewBox="0 0 24 24">
+                            <path stroke="currentColor" stroke-linejoin="round" stroke-width="2" d="M4 4h6v6H4V4Zm10 10h6v6h-6v-6Zm0-10h6v6h-6V4Zm-4 10h.01v.01H10V14Zm0 4h.01v.01H10V18Zm-3 2h.01v.01H7V20Zm0-4h.01v.01H7V16Zm-3 2h.01v.01H4V18Zm0-4h.01v.01H4V14Z" />
+                            <path stroke="currentColor" stroke-linejoin="round" stroke-width="2" d="M7 7h.01v.01H7V7Zm10 10h.01v.01H17V17Z" />
+                        </svg>
+                        Enroll
+                    </button>
+                    <div class="flex items-center w-full md:w-auto">
+                        <button id="actionsDropdownButton"
+                                data-dropdown-toggle="actionsDropdown"
+                                class="w-full md:w-auto flex items-center justify-center py-2 px-4 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-lg border border-gray-200 hover:bg-gray-100 hover:text-primary-700 focus:z-10 focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700"
+                                type="button">
+                            <svg class="-ml-1 mr-1.5 w-5 h-5"
+                                 fill="currentColor"
+                                 viewbox="0 0 20 20"
                                  xmlns="http://www.w3.org/2000/svg"
-                                 fill="none"
-                                 viewBox="0 0 14 14">
-                                <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6" />
+                                 aria-hidden="true">
+                                <path clip-rule="evenodd" fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" />
                             </svg>
-                            <span class="sr-only">Close modal</span>
+                            Actions
                         </button>
-                    </div>
-                    <form method="post"
-                          class="p-4 md:p-5 space-y-4 flex flex-col items-center justify-center mb-4">
-                        {% csrf_token %}
-                        <div class="flex w-full flex-row justify-center items-center space-x-2">
-                            <label for="id_fleet" class="font-medium text-gray-900 dark:text-white">Fleet:</label>
-                            {{ enroll_form.fleet }}
+                        <div id="actionsDropdown"
+                             class="hidden z-100 w-44 bg-white rounded divide-gray-100 shadow dark:bg-gray-700 dark:divide-gray-600">
+                            <ul class="py-1 text-sm text-gray-700 dark:text-gray-200"
+                                aria-labelledby="actionsDropdownButton">
+                                <li>
+                                    <button name="sync"
+                                            hx-post="{{ request.get_full_path }}"
+                                            hx-target="#inner-table"
+                                            hx-swap="outerHTML"
+                                            hx-push-url="true"
+                                            hx-indicator=".progress"
+                                            hx-disabled-elt="this"
+                                            class="w-full text-left py-2 px-4 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white disabled:opacity-75 disabled:cursor-wait">
+                                        Sync From MDM
+                                    </button>
+                                </li>
+                            </ul>
                         </div>
-                        {% include "includes/mdm_enroll_qr_code.html" %}
-                    </form>
+                    </div>
+                </div>
+            {% endblock table-header %}
+            <div class="bg-white sm:rounded-md overflow-x-auto">
+                {# Progress indicator #}
+                <div class="progress">
+                    <div class="indeterminate"></div>
+                </div>
+                {% render_table table %}
+            </div>
+            <div id="qr-codes-modal"
+                 tabindex="-1"
+                 aria-hidden="true"
+                 class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full">
+                <div class="relative p-4 w-full max-w-[550px] max-h-full">
+                    <div class="relative bg-white rounded-lg shadow-sm dark:bg-gray-700">
+                        <div class="flex items-center justify-between p-4 md:p-5 border-b rounded-t dark:border-gray-600 border-gray-200">
+                            <h3 class="text-xl font-semibold text-gray-900 dark:text-white">Enrollment QR codes</h3>
+                            <button type="button"
+                                    class="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center dark:hover:bg-gray-600 dark:hover:text-white"
+                                    data-modal-hide="qr-codes-modal">
+                                <svg class="w-3 h-3"
+                                     aria-hidden="true"
+                                     xmlns="http://www.w3.org/2000/svg"
+                                     fill="none"
+                                     viewBox="0 0 14 14">
+                                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6" />
+                                </svg>
+                                <span class="sr-only">Close modal</span>
+                            </button>
+                        </div>
+                        <form method="post"
+                              class="p-4 md:p-5 space-y-4 flex flex-col items-center justify-center mb-4">
+                            {% csrf_token %}
+                            <div class="flex w-full flex-row justify-center items-center space-x-2">
+                                <label for="id_fleet" class="font-medium text-gray-900 dark:text-white">Fleet:</label>
+                                {{ enroll_form.fleet }}
+                            </div>
+                            {% include "includes/mdm_enroll_qr_code.html" %}
+                        </form>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
+    {% endpartialdef devices-list-partial %}
 {% endblock content %}

--- a/config/templates/publish_mdm/devices_list.html
+++ b/config/templates/publish_mdm/devices_list.html
@@ -7,7 +7,7 @@
         display:inline;
     }
     .htmx-request.syncing {
-        display:block;
+        display:inline-flex;
     }
     </style>
 {% endblock extra-css %}
@@ -33,48 +33,30 @@
                         </svg>
                         Enroll
                     </button>
-                    <div class="flex items-center w-full md:w-auto">
-                        <button id="actionsDropdownButton"
-                                data-dropdown-toggle="actionsDropdown"
-                                class="w-full md:w-auto flex items-center justify-center py-2 px-4 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-lg border border-gray-200 hover:bg-gray-100 hover:text-primary-700 focus:z-10 focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700"
-                                type="button">
-                            <svg class="-ml-1 mr-1.5 w-5 h-5"
-                                 fill="currentColor"
-                                 viewbox="0 0 20 20"
-                                 xmlns="http://www.w3.org/2000/svg"
-                                 aria-hidden="true">
-                                <path clip-rule="evenodd" fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" />
-                            </svg>
-                            Actions
-                        </button>
-                        <div id="actionsDropdown"
-                             class="hidden z-100 w-44 bg-white rounded divide-gray-100 shadow dark:bg-gray-700 dark:divide-gray-600">
-                            <ul class="py-1 text-sm text-gray-700 dark:text-gray-200"
-                                aria-labelledby="actionsDropdownButton">
-                                <li>
-                                    <button name="sync"
-                                            hx-post="{{ request.get_full_path }}"
-                                            hx-target="#inner-table"
-                                            hx-swap="outerHTML"
-                                            hx-push-url="true"
-                                            hx-indicator=".syncing"
-                                            hx-disabled-elt="this"
-                                            class="w-full text-left py-2 px-4 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white disabled:opacity-75 disabled:cursor-wait">
-                                        Sync From MDM
-                                    </button>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
+                    <button name="sync"
+                            hx-post="{{ request.get_full_path }}"
+                            hx-target="#inner-table"
+                            hx-swap="outerHTML"
+                            hx-indicator=".syncing"
+                            hx-disabled-elt="this"
+                            class="btn btn-outline btn-primary text-sm px-4 py-2 disabled:opacity-50 disabled:cursor-not-allowed">
+                        Sync From MDM
+                        <svg aria-hidden="true"
+                             role="status"
+                             class="syncing hidden items-center w-4.5 h-4.5 ml-1.5 -mr-1 -mt-0.5 me-3 text-gray-200 animate-spin dark:text-gray-600"
+                             viewBox="0 0 100 101"
+                             fill="none"
+                             xmlns="http://www.w3.org/2000/svg">
+                            <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor" />
+                            <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="#1C64F2" />
+                        </svg>
+                    </button>
                 </div>
             {% endblock table-header %}
             <div class="bg-white sm:rounded-md overflow-x-auto">
                 {# Progress indicator #}
                 <div class="progress">
                     <div class="indeterminate"></div>
-                </div>
-                <div class="syncing hidden mb-1">
-                    <span class="px-3 py-1 text-xs font-medium leading-none text-center text-primary-700 bg-primary-200 rounded-full animate-pulse dark:bg-blue-900 dark:text-blue-200">Syncing...</span>
                 </div>
                 {% render_table table %}
             </div>

--- a/config/templates/publish_mdm/devices_list.html
+++ b/config/templates/publish_mdm/devices_list.html
@@ -6,6 +6,9 @@
     .htmx-request.loading {
         display:inline;
     }
+    .htmx-request.syncing {
+        display:block;
+    }
     </style>
 {% endblock extra-css %}
 {% block content %}
@@ -54,7 +57,7 @@
                                             hx-target="#inner-table"
                                             hx-swap="outerHTML"
                                             hx-push-url="true"
-                                            hx-indicator=".progress"
+                                            hx-indicator=".syncing"
                                             hx-disabled-elt="this"
                                             class="w-full text-left py-2 px-4 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white disabled:opacity-75 disabled:cursor-wait">
                                         Sync From MDM
@@ -69,6 +72,9 @@
                 {# Progress indicator #}
                 <div class="progress">
                     <div class="indeterminate"></div>
+                </div>
+                <div class="syncing hidden mb-1">
+                    <span class="px-3 py-1 text-xs font-medium leading-none text-center text-primary-700 bg-primary-200 rounded-full animate-pulse dark:bg-blue-900 dark:text-blue-200">Syncing...</span>
                 </div>
                 {% render_table table %}
             </div>


### PR DESCRIPTION
This PR adds a "Sync from MDM" button in the Devices list page, which invokes `sync_fleet()` for each of the current organization's fleets. The devices list is updated with the latest information after the sync operation via HTMX.
![2025-06-06_18-59](https://github.com/user-attachments/assets/b6939c2f-542e-4464-9467-49c667db5aaf)
