### PR TITLE
Delete a TinyMDM group when a Fleet is deleted.

### DIFF
--- a/apps/mdm/admin.py
+++ b/apps/mdm/admin.py
@@ -210,7 +210,7 @@ class FleetAdmin(admin.ModelAdmin):
                         request,
                         mark_safe(
                             "Cannot delete the following fleets because they have "
-                            f"devices linked to them: {linebreaks('\n'.join(has_devices))}"
+                            f"devices linked to them: {linebreaks('\n'.join(sorted(has_devices)))}"
                         ),
                     )
 
@@ -219,7 +219,7 @@ class FleetAdmin(admin.ModelAdmin):
                         request,
                         mark_safe(
                             "Cannot delete the following fleets due a TinyMDM API error: "
-                            f"{linebreaks('\n'.join(api_errors))}Please try again later."
+                            f"{linebreaks('\n'.join(sorted(api_errors)))}Please try again later."
                         ),
                     )
 

--- a/apps/mdm/admin.py
+++ b/apps/mdm/admin.py
@@ -112,14 +112,10 @@ class FleetAdmin(admin.ModelAdmin):
                     )
             else:
                 error = "Cannot delete the fleet. Please try again later."
+
             if error:
                 messages.error(request, error)
-
-                # TODO: need to do something else if popup or no change perm?
-                # (like in response_delete() called below after successful deletion)
-                return redirect(
-                    "admin:{}_{}_changelist".format(self.opts.app_label, self.opts.model_name)
-                )
+                return redirect("admin:mdm_fleet_changelist")
             # END ADDED CODE
 
             obj_display = str(obj)

--- a/tests/mdm/test_admin.py
+++ b/tests/mdm/test_admin.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.urls import reverse
 from django.utils.html import linebreaks
 from import_export.tmp_storages import TempFolderStorage
-from pytest_django.asserts import assertContains, assertNotContains
+from pytest_django.asserts import assertContains, assertNotContains, assertRedirects
 from requests.exceptions import HTTPError
 
 from apps.mdm.import_export import DeviceResource
@@ -225,6 +225,7 @@ class TestFleetAdmin(TestAdmin):
         assertContains(response, "Cannot delete the fleet. Please try again later.")
         assert Fleet.objects.filter(pk=fleet.pk).exists()
         assertNotContains(response, f"The fleet “{fleet}” was deleted successfully.")
+        assertRedirects(response, reverse("admin:mdm_fleet_changelist"))
 
     def test_delete_fleet_has_devices(self, user, client, mocker, set_tinymdm_env_vars):
         """Ensures a Fleet is not deleted if it's linked to some devices either in
@@ -242,6 +243,7 @@ class TestFleetAdmin(TestAdmin):
         assertContains(response, "Cannot delete the fleet because it has devices linked to it.")
         assert Fleet.objects.filter(pk=fleet.pk).exists()
         assertNotContains(response, f"The fleet “{fleet}” was deleted successfully.")
+        assertRedirects(response, reverse("admin:mdm_fleet_changelist"))
 
     def test_delete_fleet_api_error(self, user, client, mocker, set_tinymdm_env_vars):
         """Ensures a Fleet is not deleted if an API error occurs when deleting the
@@ -263,6 +265,7 @@ class TestFleetAdmin(TestAdmin):
         )
         assert Fleet.objects.filter(pk=fleet.pk).exists()
         assertNotContains(response, f"The fleet “{fleet}” was deleted successfully.")
+        assertRedirects(response, reverse("admin:mdm_fleet_changelist"))
 
     def test_delete_selected_fully_successful(self, user, client, mocker, set_tinymdm_env_vars):
         """Ensures fleets are successfully deleted using the delete_selected action

--- a/tests/mdm/test_admin.py
+++ b/tests/mdm/test_admin.py
@@ -2,7 +2,7 @@ import pytest
 from django.conf import settings
 from django.urls import reverse
 from import_export.tmp_storages import TempFolderStorage
-from pytest_django.asserts import assertContains
+from pytest_django.asserts import assertContains, assertNotContains
 from requests.exceptions import HTTPError
 
 from apps.mdm.import_export import DeviceResource
@@ -209,6 +209,7 @@ class TestFleetAdmin(TestAdmin):
         assert response.status_code == 200
         mock_delete_group.assert_called_once()
         assert not Fleet.objects.filter(pk=fleet.pk).exists()
+        assertContains(response, f"The fleet “{fleet}” was deleted successfully.")
 
     def test_delete_fleet_no_api_credentials(self, user, client, mocker):
         """Ensures a Fleet is not deleted if TinyMDM API access is not configured."""
@@ -222,6 +223,7 @@ class TestFleetAdmin(TestAdmin):
         mock_delete_group.assert_not_called()
         assertContains(response, "Cannot delete the fleet. Please try again later.")
         assert Fleet.objects.filter(pk=fleet.pk).exists()
+        assertNotContains(response, f"The fleet “{fleet}” was deleted successfully.")
 
     def test_delete_fleet_has_devices(self, user, client, mocker, set_tinymdm_env_vars):
         """Ensures a Fleet is not deleted if it's linked to some devices either in
@@ -238,6 +240,7 @@ class TestFleetAdmin(TestAdmin):
         mock_delete_group.assert_called_once()
         assertContains(response, "Cannot delete the fleet because it has devices linked to it.")
         assert Fleet.objects.filter(pk=fleet.pk).exists()
+        assertNotContains(response, f"The fleet “{fleet}” was deleted successfully.")
 
     def test_delete_fleet_api_error(self, user, client, mocker, set_tinymdm_env_vars):
         """Ensures a Fleet is not deleted if an API error occurs when deleting the
@@ -258,3 +261,4 @@ class TestFleetAdmin(TestAdmin):
             response, "Cannot delete the fleet due a TinyMDM API error. Please try again later."
         )
         assert Fleet.objects.filter(pk=fleet.pk).exists()
+        assertNotContains(response, f"The fleet “{fleet}” was deleted successfully.")

--- a/tests/mdm/test_tasks.py
+++ b/tests/mdm/test_tasks.py
@@ -350,3 +350,58 @@ class TestTasks:
         assert download_qr_code_request.called_once
         assert fleet.enroll_qr_code is not None
         assert fleet.enroll_qr_code.read() == qr_code
+
+    def test_delete_group_successful(self, fleet, requests_mock, set_tinymdm_env_vars):
+        """Ensure deleting a group succeeds if it's not linked to devices in the
+        database and in TinyMDM.
+        """
+        get_group_devices_request = requests_mock.get(
+            f"https://www.tinymdm.net/api/v1/groups/{fleet.mdm_group_id}/devices",
+            json={"results": []},
+        )
+        delete_device_request = requests_mock.delete(
+            f"https://www.tinymdm.net/api/v1/groups/{fleet.mdm_group_id}", status_code=204
+        )
+        session = tasks.get_tinymdm_session()
+        result = tasks.delete_group(session, fleet)
+
+        assert result
+        assert get_group_devices_request.called_once
+        assert delete_device_request.called_once
+
+    def test_delete_group_fails_if_devices_in_db(self, fleet, requests_mock, set_tinymdm_env_vars):
+        """Ensure deleting a group fails if it's linked to devices in the database."""
+        DeviceFactory(fleet=fleet)
+        session = tasks.get_tinymdm_session()
+        result = tasks.delete_group(session, fleet)
+
+        assert not result
+
+    def test_delete_group_fails_if_devices_in_tinymdm(
+        self, fleet, requests_mock, set_tinymdm_env_vars
+    ):
+        """Ensure deleting a group fails if it's linked to devices in TinyMDM."""
+        get_group_devices_request = requests_mock.get(
+            f"https://www.tinymdm.net/api/v1/groups/{fleet.mdm_group_id}/devices",
+            json={"results": [{"id": "somedevice"}]},
+        )
+        session = tasks.get_tinymdm_session()
+        result = tasks.delete_group(session, fleet)
+
+        assert not result
+        assert get_group_devices_request.called_once
+
+    def test_delete_group_succeeds_if_does_not_exist_in_tinymdm(
+        self, fleet, requests_mock, set_tinymdm_env_vars
+    ):
+        """Ensure delete_group() returns True if a group with the Fleet's mdm_group_id
+        does not exist in TinyMDM.
+        """
+        get_group_devices_request = requests_mock.get(
+            f"https://www.tinymdm.net/api/v1/groups/{fleet.mdm_group_id}/devices", status_code=404
+        )
+        session = tasks.get_tinymdm_session()
+        result = tasks.delete_group(session, fleet)
+
+        assert result
+        assert get_group_devices_request.called_once


### PR DESCRIPTION
This PR adds deletion of a group in TinyMDM when a Fleet is deleted. Currently, Fleets can only be deleted in Admin. If a Fleet has devices either in the database or in TinyMDM it cannot be deleted.