### PR TITLE
Support enrolling BYOD devices in the Devices list page.

### DIFF
--- a/apps/mdm/tasks.py
+++ b/apps/mdm/tasks.py
@@ -332,3 +332,29 @@ def get_enrollment_qr_code(session: Session, fleet: Fleet):
     response.raise_for_status()
     # Update the enroll_qr_code field. Do not call Fleet.save()
     fleet.enroll_qr_code.save(f"{fleet}.png", ContentFile(response.content), save=False)
+
+
+def create_user(session: Session, name: str, email: str, fleet: Fleet):
+    """Creates a TinyMDM user and adds them to the provided fleet's TinyMDM group."""
+    logger.info("Creating a TinyMDM user", name=name, email=email)
+    data = {
+        "name": name,
+        "is_anonymous": False,
+        "email": email,
+        "send_email": True,
+    }
+    response = session.post("https://www.tinymdm.net/api/v1/users", json=data)
+    response.raise_for_status()
+    logger.info("Successfully created a TinyMDM user", user=response.content)
+    user_id = response.json()["id"]
+    logger.info(
+        "Adding new TinyMDM user to a group",
+        user_id=user_id,
+        fleet=fleet,
+        group_id=fleet.mdm_group_id,
+    )
+    response = session.post(
+        f"https://www.tinymdm.net/api/v1/groups/{fleet.mdm_group_id}/users/{user_id}",
+        headers={"content-type": "application/json"},
+    )
+    response.raise_for_status()

--- a/apps/publish_mdm/forms.py
+++ b/apps/publish_mdm/forms.py
@@ -592,3 +592,20 @@ class DeviceEnrollmentQRCodeForm(PlatformFormMixin, forms.Form):
         self.fields["fleet"].widget.attrs["hx-post"] = reverse_lazy(
             "publish_mdm:fleet-qr-code", args=[organization.slug]
         )
+
+
+class BYODDeviceEnrollmentForm(PlatformFormMixin, forms.Form):
+    """A form for enrolling a BYOD device in the Device list page."""
+
+    fleet = forms.ModelChoiceField(
+        # The queryset will be updated based on the current organization in __init__()
+        queryset=None,
+        widget=Select,
+        empty_label="Select a Fleet to join",
+    )
+    name = forms.CharField(widget=TextInput, label="Your name")
+    email = forms.EmailField(widget=EmailInput, label="Your email")
+
+    def __init__(self, organization, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["fleet"].queryset = organization.fleets.all()

--- a/apps/publish_mdm/urls.py
+++ b/apps/publish_mdm/urls.py
@@ -147,4 +147,9 @@ urlpatterns = [
         views.fleet_qr_code,
         name="fleet-qr-code",
     ),
+    path(
+        "o/<slug:organization_slug>/add-byod-device/",
+        views.add_byod_device,
+        name="add-byod-device",
+    ),
 ]

--- a/apps/publish_mdm/views.py
+++ b/apps/publish_mdm/views.py
@@ -33,6 +33,7 @@ from apps.mdm.models import Device, FirmwareSnapshot, Fleet, Policy
 from apps.mdm.tasks import (
     add_group_to_policy,
     create_group,
+    create_user,
     get_enrollment_qr_code,
     get_tinymdm_session,
 )
@@ -61,6 +62,7 @@ from .forms import (
     FleetEditForm,
     CentralServerFrontendForm,
     DeviceEnrollmentQRCodeForm,
+    BYODDeviceEnrollmentForm,
 )
 from .import_export import AppUserResource
 from .models import FormTemplateVersion, FormTemplate, AppUser, Project, CentralServer
@@ -746,6 +748,7 @@ def devices_list(request: HttpRequest, organization_slug):
             items=[("Devices", "devices-list")],
         ),
         "enroll_form": DeviceEnrollmentQRCodeForm(request.organization),
+        "byod_form": BYODDeviceEnrollmentForm(request.organization, prefix="byod"),
     }
     if request.htmx:
         template = "patterns/tables/table-partial.html"
@@ -922,4 +925,44 @@ def fleet_qr_code(request: HttpRequest, organization_slug):
         not_found = True
     return render(
         request, "includes/mdm_enroll_qr_code.html", {"fleet": fleet, "not_found": not_found}
+    )
+
+
+@login_required
+def add_byod_device(request: HttpRequest, organization_slug):
+    """Create a TinyMDM user and add them to the TinyMDM group of the selected
+    Fleet. If successful, the user should receive an email from TinyMDM with
+    instructions on how to enroll a device.
+    """
+    form = BYODDeviceEnrollmentForm(request.organization, request.POST or None, prefix="byod")
+    enrollment_messages = []
+    if form.is_valid():
+        success = False
+        error = None
+        if session := get_tinymdm_session():
+            try:
+                create_user(session, **form.cleaned_data)
+            except RequestException as e:
+                if (
+                    hasattr(e.request, "url")
+                    and e.request.url.endswith("/users")
+                    and getattr(e.response, "status_code", None) == 409
+                ):
+                    error = "Another MDM user exists with that email. Please enter another email."
+            else:
+                success = True
+        if success:
+            message = messages.Message(
+                messages.SUCCESS, "Please check your email for a link to download the TinyMDM app."
+            )
+        else:
+            message = messages.Message(
+                messages.ERROR,
+                error or "Sorry, we cannot enroll you at this time. Please try again later.",
+            )
+        enrollment_messages.append(message)
+    return render(
+        request,
+        "includes/device_enrollment_form.html",
+        {"form": form, "enrollment_messages": enrollment_messages},
     )

--- a/config/templates/includes/device_enrollment_form.html
+++ b/config/templates/includes/device_enrollment_form.html
@@ -1,0 +1,10 @@
+{% include "includes/messages.html" with messages=enrollment_messages id_prefix="byod-device-alert" %}
+<div class="grid grid-cols-1 gap-4">
+    {% for field in form.visible_fields %}
+        <div id="id_{{ field.name }}_container">
+            {{ field.label_tag }}
+            {{ field }}
+            {{ field.errors }}
+        </div>
+    {% endfor %}
+</div>

--- a/config/templates/includes/messages.html
+++ b/config/templates/includes/messages.html
@@ -1,8 +1,8 @@
 {% if messages %}
-    <section class="py-2 md:py-4">
+    <section class="py-2 md:py-4 hidden has-[.alert:not(.hidden)]:block">
         {% for message in messages %}
-            <div id="alert-{{ forloop.counter }}"
-                 class="flex items-center p-4 mb-4 rounded-lg {% if message.tags == 'info' or message.tags == 'success' %}text-primary-700 bg-primary-100 dark:bg-gray-800 dark:text-primary-300{% else %} text-red bg-red-50 dark:bg-gray-800 dark:text-red-400{% endif %}"
+            <div id="{{ id_prefix|default:'alert' }}-{{ forloop.counter }}"
+                 class="alert flex items-center p-4 mb-4 rounded-lg {% if message.tags == 'info' or message.tags == 'success' %}text-primary-700 bg-primary-100 dark:bg-gray-800 dark:text-primary-300{% else %} text-red bg-red-50 dark:bg-gray-800 dark:text-red-400{% endif %}"
                  role="alert">
                 <svg class="flex-shrink-0 w-4 h-4 dark:text-gray-300"
                      aria-hidden="true"
@@ -15,7 +15,7 @@
                 <div class="ms-3 text-sm font-medium">{{ message }}</div>
                 <button type="button"
                         class="ms-auto -mx-1.5 -my-1.5 bg-gray-50 text-gray-500 rounded-lg focus:ring-2 focus:ring-gray-400 p-1.5 hover:bg-gray-200 inline-flex items-center justify-center h-8 w-8 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white"
-                        data-dismiss-target="#alert-{{ forloop.counter }}"
+                        data-dismiss-target="#{{ id_prefix|default:'alert' }}-{{ forloop.counter }}"
                         aria-label="Close">
                     <span class="sr-only">Dismiss</span>
                     <svg class="w-3 h-3"

--- a/config/templates/publish_mdm/devices_list.html
+++ b/config/templates/publish_mdm/devices_list.html
@@ -57,15 +57,62 @@
                             <span class="sr-only">Close modal</span>
                         </button>
                     </div>
-                    <form method="post"
-                          class="p-4 md:p-5 space-y-4 flex flex-col items-center justify-center mb-4">
-                        {% csrf_token %}
-                        <div class="flex w-full flex-row justify-center items-center space-x-2">
-                            <label for="id_fleet" class="font-medium text-gray-900 dark:text-white">Fleet:</label>
-                            {{ enroll_form.fleet }}
+                    <div x-data="{device: null}" class="p-4 md:p-5">
+                        <div class="flex w-full flex-col md:flex-row justify-center items-center space-x-0 md:space-x-2">
+                            <label class="font-medium text-gray-900 dark:text-white">Select a device type:</label>
+                            <div class="flex items-center">
+                                <label class="dark:text-white">
+                                    <input type="radio"
+                                           x-model="device"
+                                           value="byod"
+                                           autocomplete="off"
+                                           class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600 selectable">
+                                    BYOD
+                                </label>
+                            </div>
+                            <div class="flex items-center">
+                                <label class="dark:text-white">
+                                    <input type="radio"
+                                           x-model="device"
+                                           value="corporate"
+                                           autocomplete="off"
+                                           class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600 selectable">
+                                    Corporate-owned
+                                </label>
+                            </div>
                         </div>
-                        {% include "includes/mdm_enroll_qr_code.html" %}
-                    </form>
+                        <form method="post"
+                              x-show="device == 'byod'"
+                              x-cloak
+                              hx-post="{% url 'publish_mdm:add-byod-device' request.organization.slug %}"
+                              hx-target="#byod"
+                              hx-swap="innerHTML"
+                              hx-disabled-elt="#byod-button"
+                              class="mt-4">
+                            {% csrf_token %}
+                            <p class="mb-4 dark:text-gray-400">
+                                Please fill in the form below and you will receive instructions on how to enroll your device.
+                            </p>
+                            <div id="byod">{% include "includes/device_enrollment_form.html" with form=byod_form %}</div>
+                            <div class="w-full mt-6">
+                                <button id="byod-button"
+                                        class="btn btn-outline btn-primary disabled:opacity-50 disabled:cursor-not-allowed">
+                                    Submit
+                                </button>
+                            </div>
+                        </form>
+                        <form method="post"
+                              x-show="device == 'corporate'"
+                              x-cloak
+                              class="space-y-4 flex flex-col items-center justify-center mt-4">
+                            {% csrf_token %}
+                            <div class="flex w-full flex-row justify-center items-center space-x-2">
+                                <label for="id_fleet" class="font-medium text-gray-900 dark:text-white">Fleet:</label>
+                                {{ enroll_form.fleet }}
+                            </div>
+                            {% include "includes/mdm_enroll_qr_code.html" %}
+                        </form>
+                    </div>
                 </div>
             </div>
         </div>

--- a/tests/mdm/test_tasks.py
+++ b/tests/mdm/test_tasks.py
@@ -350,3 +350,37 @@ class TestTasks:
         assert download_qr_code_request.called_once
         assert fleet.enroll_qr_code is not None
         assert fleet.enroll_qr_code.read() == qr_code
+
+    def test_create_user(self, fleet, requests_mock, set_tinymdm_env_vars):
+        """Ensures create_user() makes the expected API requests to create a user
+        and add them to a group.
+        """
+        name = fake.name()
+        email = fake.email()
+        user_response = {
+            "id": fake.pystr(),
+            "name": name,
+            "email": email,
+            "enrollment_token": fake.pystr(),
+            "is_anonymous": False,
+            "policy_id": None,
+            "group_id": None,
+        }
+        create_user_request = requests_mock.post(
+            "https://www.tinymdm.net/api/v1/users", json=user_response
+        )
+        add_to_group_request = requests_mock.post(
+            f"https://www.tinymdm.net/api/v1/groups/{fleet.mdm_group_id}/users/{user_response['id']}"
+        )
+        session = tasks.get_tinymdm_session()
+        tasks.create_user(session, name, email, fleet)
+
+        assert create_user_request.called_once
+        assert create_user_request.last_request.json() == {
+            "name": name,
+            "is_anonymous": False,
+            "email": email,
+            "send_email": True,
+        }
+        assert add_to_group_request.called_once
+        assert not add_to_group_request.last_request.body

--- a/tests/publish_mdm/test_forms.py
+++ b/tests/publish_mdm/test_forms.py
@@ -8,6 +8,7 @@ from requests.exceptions import ConnectionError
 
 from apps.patterns.widgets import BaseEmailInput
 from apps.publish_mdm.forms import (
+    BYODDeviceEnrollmentForm,
     CentralServerForm,
     CentralServerFrontendForm,
     DeviceEnrollmentQRCodeForm,
@@ -378,7 +379,7 @@ class TestFleetForm:
 
 
 @pytest.mark.django_db
-class TestDeviceQRCodeForm:
+class TestDeviceEnrollmentForm:
     @pytest.fixture
     def organization(self):
         return OrganizationFactory()
@@ -387,11 +388,12 @@ class TestDeviceQRCodeForm:
     def fleets(self, organization):
         return FleetFactory.create_batch(3, organization=organization)
 
-    def test_fleet_choices(self, organization, fleets):
+    @pytest.mark.parametrize("form_class", [DeviceEnrollmentQRCodeForm, BYODDeviceEnrollmentForm])
+    def test_fleet_choices(self, organization, fleets, form_class):
         """Ensures the choices for the fleet field are the current organization's
         fleets only.
         """
         # Create some fleets in another organization
         FleetFactory.create_batch(2, organization=OrganizationFactory())
-        form = DeviceEnrollmentQRCodeForm(organization=organization)
+        form = form_class(organization=organization)
         assertQuerySetEqual(form.fields["fleet"].queryset, fleets, ordered=False)


### PR DESCRIPTION
The "Enroll" button now opens a modal with radio buttons to select between BYOD and Corporate-owned devices. Selecting "Corporate-owned" will show QR codes for the current organization's fleets as before. Selecting "BYOD" will show a form which when submitted will create a TinyMDM user and add the user to the selected fleet's TinyMDM group.

![2025-06-19_18-45](https://github.com/user-attachments/assets/762db3ee-8881-4d57-9b19-01bde8d4f397)
