### PR TITLE
Fix removing and adding Google account connections in the Account Settings page.

### DIFF
--- a/config/templates/socialaccount/connections.html
+++ b/config/templates/socialaccount/connections.html
@@ -7,27 +7,34 @@
             <h2 class="text-2xl font-bold text-center text-gray-800 dark:text-white">Account Connections</h2>
             <p class="text-gray-600 dark:text-gray-400 text-center mt-2">Manage your linked third-party accounts.</p>
             {% if form.accounts %}
-                <ul class="mt-4 space-y-4">
-                    {% for base_account in form.accounts %}
-                        {% with base_account.get_provider_account as account %}
-                            <li class="flex items-center justify-between p-3 bg-gray-100 dark:bg-gray-700 rounded-lg">
-                                <div class="flex items-center space-x-3">
-                                    <input type="radio"
-                                           id="google-account"
-                                           name="account"
-                                           class="w-4 h-4 text-blue-600 border-gray-300 focus:ring-blue-500">
-                                    <label for="google-account"
-                                           class="text-gray-800 dark:text-gray-200 font-medium">{{ account }}</label>
-                                </div>
-                                <a href="{% url 'socialaccount_connections' %}?remove={{ base_account.id }}"
-                                   class="text-red-500 hover:text-red-700 text-sm">Remove</a>
-                            </li>
-                        {% endwith %}
+                <form method="post"
+                      action="{% url 'socialaccount_connections' %}"
+                      class="mt-4 space-y-4">
+                    {% for error in form.non_field_errors %}
+                        <div class="alert text-sm p-3 rounded-lg text-red bg-red-50 dark:bg-gray-800 dark:text-red-400"
+                             role="alert">{{ error }}</div>
                     {% endfor %}
-                </ul>
+                    {% csrf_token %}
+                    {% with num_accounts=form.fields.account.choices|length %}
+                        {% for acc in form.fields.account.choices %}
+                            {% with account=acc.0.instance.get_provider_account %}
+                                <div class="flex items-center justify-between  p-3 bg-gray-100 dark:bg-gray-700 rounded-lg">
+                                    <span class="text-gray-800 dark:text-gray-200 font-medium">{{ account }}</span>
+                                    {% if num_accounts != 1 %}
+                                        <button name="account"
+                                                value="{{ account.account.pk }}"
+                                                class="text-red-500 hover:text-red-700 text-sm cursor-pointer">
+                                            Remove
+                                        </button>
+                                    {% endif %}
+                                </div>
+                            {% endwith %}
+                        {% endfor %}
+                    {% endwith %}
+                </form>
             {% endif %}
             <div class="mt-6">
-                <a href="{% provider_login_url 'google' %}"
+                <a href="{% provider_login_url 'google' process='connect' %}"
                    class="w-full flex items-center justify-center bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-4 rounded-lg shadow-md transition duration-300">
                     <svg class="w-5 h-5 mr-2" viewBox="0 0 48 48">
                         <path fill="#4285F4" d="M24 9.5c3.54 0 6.67 1.22 9.19 3.25l6.85-6.85C35.91 2.15 30.3 0 24 0 14.66 0 6.67 5.35 2.8 13.16l8.07 6.27C13.11 12.65 18.11 9.5 24 9.5z">
@@ -42,10 +49,6 @@
                     Add Google Account
                 </a>
             </div>
-            <p class="text-center text-gray-500 dark:text-gray-400 text-sm mt-4">
-                <a href="{% url 'account_login' %}"
-                   class="text-blue-500 hover:underline">Back to login</a>
-            </p>
         </div>
     </div>
 {% endblock content %}


### PR DESCRIPTION
This PR fixes removing and adding Google account connections in the Account Settings page. If a user has more than one Google account linked to their Publish MDM account, a "Remove" button will be shown for each:
![2025-06-30_19-08](https://github.com/user-attachments/assets/ac531994-839f-44d5-b0dc-49f8c953b867)
The "Add Google Account" button links another Google account to the currently logged in Publish MDM account.
