### PR TITLE
Warn user if the TinyMDM license limit is reached.

### DIFF
--- a/apps/mdm/tasks.py
+++ b/apps/mdm/tasks.py
@@ -444,3 +444,31 @@ def create_user(session: Session, name: str, email: str, fleet: Fleet):
         f"https://www.tinymdm.net/api/v1/groups/{fleet.mdm_group_id}/users/{user_id}",
         headers={"content-type": "application/json"},
     )
+
+
+def check_license_limit(session):
+    """Gets the devices limit as per the TinyMDM account's license and the number
+    of devices currently enrolled.
+    """
+    logger.info("Checking TinyMDM license limit")
+    response = request(
+        session,
+        "GET",
+        "https://www.tinymdm.net/api/v1/enterprise/info",
+        headers={"content-type": "application/json"},
+    )
+    limit = response.json()["paid_licence"]
+    response = request(
+        session,
+        "GET",
+        "https://www.tinymdm.net/api/v1/devices",
+        headers={"content-type": "application/json"},
+    )
+    enrolled = response.json()["count"]
+    logger.info(
+        "TinyMDM license limit check done",
+        limit=limit,
+        enrolled=enrolled,
+        limit_reached=(enrolled >= limit),
+    )
+    return limit, enrolled

--- a/apps/publish_mdm/forms.py
+++ b/apps/publish_mdm/forms.py
@@ -594,7 +594,7 @@ class DeviceEnrollmentQRCodeForm(PlatformFormMixin, forms.Form):
             attrs={
                 "hx-trigger": "change",
                 "hx-target": "#qr-code",
-                "hx-swap": "outerHTML",
+                "hx-swap": "innerHTML",
                 "hx-indicator": ".loading",
             }
         ),

--- a/apps/publish_mdm/urls.py
+++ b/apps/publish_mdm/urls.py
@@ -157,4 +157,9 @@ urlpatterns = [
         views.add_byod_device,
         name="add-byod-device",
     ),
+    path(
+        "check-mdm-license-limit/",
+        views.check_mdm_license_limit,
+        name="check-mdm-license-limit",
+    ),
 ]

--- a/apps/publish_mdm/views.py
+++ b/apps/publish_mdm/views.py
@@ -12,7 +12,6 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.html import mark_safe
 from django.utils.timezone import localdate
-from django.views.decorators.cache import cache_page
 from django_tables2.config import RequestConfig
 from import_export.results import RowResult
 from import_export.tmp_storages import MediaStorage
@@ -1094,7 +1093,6 @@ def add_byod_device(request: HttpRequest, organization_slug):
     )
 
 
-@cache_page(60 * 60)
 @login_required
 def check_mdm_license_limit(request: HttpRequest):
     """Checks if the TinyMDM account's device limit has been reached. If it has

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -10,9 +10,3 @@ CELERY_TASK_EAGER_PROPAGATES = True
 MEDIA_ROOT = os.path.join(BASE_DIR, "test_media")  # noqa
 
 STORAGES["default"] = {"BACKEND": "django.core.files.storage.FileSystemStorage"}  # noqa
-
-CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
-    }
-}

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -10,3 +10,9 @@ CELERY_TASK_EAGER_PROPAGATES = True
 MEDIA_ROOT = os.path.join(BASE_DIR, "test_media")  # noqa
 
 STORAGES["default"] = {"BACKEND": "django.core.files.storage.FileSystemStorage"}  # noqa
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+    }
+}

--- a/config/templates/includes/mdm_enroll_qr_code.html
+++ b/config/templates/includes/mdm_enroll_qr_code.html
@@ -1,30 +1,28 @@
-<div id="qr-code" class="w-full relative">
-    <div class="loading hidden absolute text-center w-full top-[-11px]">
-        <span class="px-3 py-1 text-xs font-medium leading-none text-center text-primary-700 bg-primary-200 rounded-full animate-pulse dark:bg-blue-900 dark:text-blue-200">loading...</span>
-    </div>
-    {% if error %}
-        <div class="flex flex-col items-center justify-center w-full aspect-square text-red bg-red-50 dark:bg-gray-800 dark:text-red-400">
-            <p class="text-center">{{ error }}</p>
-        </div>
-    {% else %}
-        <div class="flex flex-col items-center justify-center w-full aspect-square border bg-primary-100 dark:bg-gray-700 border-gray-200 dark:border-gray-600">
-            {% if fleet.enroll_qr_code %}
-                <img src="{{ fleet.enroll_qr_code.url }}"
-                     alt="{{ fleet }} QR code"
-                     width="485"
-                     height="485">
-            {% else %}
-                <svg class="placeholder w-[48px] h-[48px] text-gray-200 dark:text-gray-600"
-                     aria-hidden="true"
-                     xmlns="http://www.w3.org/2000/svg"
-                     width="24"
-                     height="24"
-                     fill="none"
-                     viewBox="0 0 24 24">
-                    <path stroke="currentColor" stroke-linejoin="round" stroke-width="2" d="M4 4h6v6H4V4Zm10 10h6v6h-6v-6Zm0-10h6v6h-6V4Zm-4 10h.01v.01H10V14Zm0 4h.01v.01H10V18Zm-3 2h.01v.01H7V20Zm0-4h.01v.01H7V16Zm-3 2h.01v.01H4V18Zm0-4h.01v.01H4V14Z" />
-                    <path stroke="currentColor" stroke-linejoin="round" stroke-width="2" d="M7 7h.01v.01H7V7Zm10 10h.01v.01H17V17Z" />
-                </svg>
-            {% endif %}
-        </div>
-    {% endif %}
+<div class="loading hidden absolute text-center w-full top-[-11px]">
+    <span class="px-3 py-1 text-xs font-medium leading-none text-center text-primary-700 bg-primary-200 rounded-full animate-pulse dark:bg-blue-900 dark:text-blue-200">loading...</span>
 </div>
+{% if error %}
+    <div class="flex flex-col items-center justify-center w-full aspect-square text-red bg-red-50 dark:bg-gray-800 dark:text-red-400">
+        <p class="text-center">{{ error }}</p>
+    </div>
+{% else %}
+    <div class="flex flex-col items-center justify-center w-full aspect-square border bg-primary-100 dark:bg-gray-700 border-gray-200 dark:border-gray-600">
+        {% if fleet.enroll_qr_code %}
+            <img src="{{ fleet.enroll_qr_code.url }}"
+                 alt="{{ fleet }} QR code"
+                 width="485"
+                 height="485">
+        {% else %}
+            <svg class="placeholder w-[48px] h-[48px] text-gray-200 dark:text-gray-600"
+                 aria-hidden="true"
+                 xmlns="http://www.w3.org/2000/svg"
+                 width="24"
+                 height="24"
+                 fill="none"
+                 viewBox="0 0 24 24">
+                <path stroke="currentColor" stroke-linejoin="round" stroke-width="2" d="M4 4h6v6H4V4Zm10 10h6v6h-6v-6Zm0-10h6v6h-6V4Zm-4 10h.01v.01H10V14Zm0 4h.01v.01H10V18Zm-3 2h.01v.01H7V20Zm0-4h.01v.01H7V16Zm-3 2h.01v.01H4V18Zm0-4h.01v.01H4V14Z" />
+                <path stroke="currentColor" stroke-linejoin="round" stroke-width="2" d="M7 7h.01v.01H7V7Zm10 10h.01v.01H17V17Z" />
+            </svg>
+        {% endif %}
+    </div>
+{% endif %}

--- a/config/templates/publish_mdm/devices_list.html
+++ b/config/templates/publish_mdm/devices_list.html
@@ -20,7 +20,9 @@
                     <button type="button"
                             class="btn btn-outline btn-primary flex items-center justify-center text-sm px-4 py-2"
                             data-modal-target="qr-codes-modal"
-                            data-modal-toggle="qr-codes-modal">
+                            data-modal-toggle="qr-codes-modal"
+                            hx-get="{% url 'publish_mdm:check-mdm-license-limit' %}"
+                            hx-target="#license-limit-messages">
                         <svg class="w-[20px] h-[20px] mr-2"
                              aria-hidden="true"
                              xmlns="http://www.w3.org/2000/svg"
@@ -82,6 +84,7 @@
                             </button>
                         </div>
                         <div x-data="{device: null}" class="p-4 md:p-5">
+                            <div id="license-limit-messages"></div>
                             <div class="flex w-full flex-col md:flex-row justify-center items-center space-x-0 md:space-x-2">
                                 <label class="font-medium text-gray-900 dark:text-white">Select a device type:</label>
                                 <div class="flex items-center">

--- a/config/templates/publish_mdm/devices_list.html
+++ b/config/templates/publish_mdm/devices_list.html
@@ -12,6 +12,18 @@
     </style>
 {% endblock extra-css %}
 {% block content %}
+    <script>
+    function fixEnrollModalBackdrop() {
+        // We call window.initFlowbite() on every `htmx:afterSwap` event (in base.html).
+        // This causes the device enrollment modal to lose its backdrop if it's currently
+        // open, due to a Flowbite bug:
+        // - https://github.com/themesberg/flowbite/issues/820
+        // - https://github.com/themesberg/flowbite/issues/1042
+        // Adding `hx-on::after-swap="fixEnrollModalBackdrop()"` to any HTMX targets
+        // within the device enrollment modal fixes the issue.
+        window.FlowbiteInstances.getInstance("Modal", "qr-codes-modal").show();
+    }
+    </script>
     {% partialdef devices-list-partial inline %}
         <div id="inner-table">
             {% block table-header %}
@@ -84,7 +96,8 @@
                             </button>
                         </div>
                         <div x-data="{device: null}" class="p-4 md:p-5">
-                            <div id="license-limit-messages"></div>
+                            <div id="license-limit-messages"
+                                 hx-on::after-swap="fixEnrollModalBackdrop()"></div>
                             <div class="flex w-full flex-col md:flex-row justify-center items-center space-x-0 md:space-x-2">
                                 <label class="font-medium text-gray-900 dark:text-white">Select a device type:</label>
                                 <div class="flex items-center">
@@ -120,7 +133,9 @@
                                 <p class="mb-4 dark:text-gray-400">
                                     Please fill in the form below and you will receive instructions on how to enroll your device.
                                 </p>
-                                <div id="byod">{% include "includes/device_enrollment_form.html" with form=byod_form %}</div>
+                                <div id="byod" hx-on::after-swap="fixEnrollModalBackdrop()">
+                                    {% include "includes/device_enrollment_form.html" with form=byod_form %}
+                                </div>
                                 <div class="w-full mt-6">
                                     <button id="byod-button"
                                             class="btn btn-outline btn-primary disabled:opacity-50 disabled:cursor-not-allowed">
@@ -137,7 +152,11 @@
                                     <label for="id_fleet" class="font-medium text-gray-900 dark:text-white">Fleet:</label>
                                     {{ enroll_form.fleet }}
                                 </div>
-                                {% include "includes/mdm_enroll_qr_code.html" %}
+                                <div id="qr-code"
+                                     class="w-full relative"
+                                     hx-on::after-swap="fixEnrollModalBackdrop()">
+                                    {% include "includes/mdm_enroll_qr_code.html" %}
+                                </div>
                             </form>
                         </div>
                     </div>

--- a/tests/mdm/test_tasks.py
+++ b/tests/mdm/test_tasks.py
@@ -468,3 +468,23 @@ class TestTasks:
             assert expected_api_error in session.api_errors
             if response_json is not None:
                 assert response.json() == response_json
+
+    def test_check_license_limit(self, requests_mock, set_tinymdm_env_vars):
+        """Ensures check_license_limit() makes the expected API requests and
+        returns a tuple with the devices limit and the number of enrolled devices.
+        """
+        limit = 10
+        enrolled = 8
+        account_info_request = requests_mock.get(
+            "https://www.tinymdm.net/api/v1/enterprise/info", json={"paid_licence": limit}
+        )
+        devices_request = requests_mock.get(
+            "https://www.tinymdm.net/api/v1/devices",
+            json={"count": 8},
+        )
+        session = tasks.get_tinymdm_session()
+        result = tasks.check_license_limit(session)
+
+        assert account_info_request.called_once
+        assert devices_request.called_once
+        assert result == (limit, enrolled)


### PR DESCRIPTION
This displays a warning message if the TinyMDM license limit is reached and a user clicks on the Enroll button in the Device list page. The user can still attempt to enroll a device.

![2025-07-01_02-21](https://github.com/user-attachments/assets/89b4cbe8-876e-4a43-829f-26fe1c197a2c)
