### PR TITLE
Use currently logged-in user's credentials to download forms from Google Sheets.

### DIFF
--- a/apps/publish_mdm/consumers.py
+++ b/apps/publish_mdm/consumers.py
@@ -4,8 +4,13 @@ import traceback
 
 import structlog
 from channels.generic.websocket import WebsocketConsumer
+from django.conf import settings
 from django.template.loader import render_to_string
+from gspread.exceptions import SpreadsheetNotFound
+from gspread.utils import extract_id_from_url
 from requests import Response
+
+from apps.publish_mdm.models import FormTemplate
 
 from .etl.load import PublishTemplateEvent, publish_form_template
 
@@ -19,13 +24,24 @@ class PublishTemplateConsumer(WebsocketConsumer):
         logger.debug(f"New connection: {self.channel_layer}")
         super().connect()
 
-    def send_message(self, message: str, error: bool = False, complete: bool = False):
+    def send_message(
+        self,
+        message: str,
+        error: bool = False,
+        complete: bool = False,
+        error_summary: str | None = None,
+    ):
         """Send a message to the browser."""
         if not error:
             logger.debug(f"Sending message: {message}")
         message = render_to_string(
             "publish_mdm/ws/message.html",
-            {"message_text": message, "error": error, "complete": complete},
+            {
+                "message_text": message,
+                "error": error,
+                "complete": complete,
+                "error_summary": error_summary,
+            },
         )
         self.send(text_data=message)
 
@@ -42,11 +58,14 @@ class PublishTemplateConsumer(WebsocketConsumer):
                 logger.exception("Error publishing form")
             tbe = traceback.TracebackException.from_exception(exc=e, compact=True)
             message = "".join(tbe.format())
+            summary = None
+            if isinstance(e, SpreadsheetNotFound):
+                summary = self.get_google_picker(form_template_id=event_data.get("form_template"))
             # If the error is from ODK Central, format the error message for easier reading
             if len(e.args) >= 2 and isinstance(e.args[1], Response):
                 data = e.args[1].json()
                 message = f"ODK Central error:\n\n{pprint.pformat(data)}\n\n{message}"
-            self.send_message(message, error=True)
+            self.send_message(message, error=True, error_summary=summary)
 
     def publish_form_template(self, event_data: dict):
         """Publish a form template to ODK Central and stream progress to the browser."""
@@ -56,3 +75,18 @@ class PublishTemplateConsumer(WebsocketConsumer):
         publish_form_template(
             event=publish_event, user=self.scope["user"], send_message=self.send_message
         )
+
+    def get_google_picker(self, form_template_id):
+        """Gets the HTML for displaying a button for the user to give us permission
+        to access a FormTemplate's Google Sheet using their Google credentials.
+        """
+        form_template = FormTemplate.objects.get(id=form_template_id)
+        context = {
+            "user": self.scope["user"],
+            "google_client_id": settings.GOOGLE_CLIENT_ID,
+            "google_scopes": " ".join(settings.SOCIALACCOUNT_PROVIDERS["google"]["SCOPE"]),
+            "google_api_key": settings.GOOGLE_API_KEY,
+            "google_app_id": settings.GOOGLE_APP_ID,
+            "google_sheet_id": extract_id_from_url(form_template.template_url),
+        }
+        return render_to_string("publish_mdm/ws/form_template_access_form.html", context)

--- a/apps/publish_mdm/etl/load.py
+++ b/apps/publish_mdm/etl/load.py
@@ -68,7 +68,7 @@ def publish_form_template(event: PublishTemplateEvent, user: User, send_message:
     send_message(f"Generated version: {version}")
     # Download the template from Google Sheets
     file = form_template.download_user_google_sheet(
-        name=f"{form_template.form_id_base}-{version}.xlsx"
+        user=user, name=f"{form_template.form_id_base}-{version}.xlsx"
     )
     send_message(f"Downloaded template: {file}")
     with transaction.atomic():

--- a/apps/publish_mdm/models.py
+++ b/apps/publish_mdm/models.py
@@ -310,11 +310,9 @@ class FormTemplate(AbstractBaseModel):
             q &= models.Q(app_user_forms__app_user__name__in=names)
         return AppUser.objects.filter(q)
 
-    def download_user_google_sheet(self, name: str) -> SimpleUploadedFile:
+    def download_user_google_sheet(self, user: User, name: str) -> SimpleUploadedFile:
         """Download the Google Sheet Excel file for this form template."""
-        if not self.template_url_user:
-            raise ValueError("The user who gave access to the Google Sheet is not known.")
-        social_token = self.template_url_user.get_google_social_token()
+        social_token = user.get_google_social_token()
         if social_token is None:
             raise ValueError("User does not have a Google social token.")
         return download_user_google_sheet(

--- a/apps/publish_mdm/views.py
+++ b/apps/publish_mdm/views.py
@@ -260,7 +260,10 @@ def form_template_publish(
             ],
         ),
     }
-    return render(request, template, context)
+    response = render(request, template, context)
+    # Needed for the Google Picker popup to work
+    response.headers["Cross-Origin-Opener-Policy"] = "same-origin-allow-popups"
+    return response
 
 
 @login_required

--- a/apps/publish_mdm/views.py
+++ b/apps/publish_mdm/views.py
@@ -1,15 +1,18 @@
 import json
+from urllib.parse import urlencode
 
 import structlog
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth import logout, REDIRECT_FIELD_NAME
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.views import redirect_to_login
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.db import models, transaction
 from django.db.models import OuterRef, Q, Subquery, Value
 from django.db.models.functions import Collate, Lower, NullIf
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import get_object_or_404, redirect, render, resolve_url
 from django.utils.html import mark_safe
 from django.utils.timezone import localdate
 from django_tables2.config import RequestConfig
@@ -220,6 +223,17 @@ def form_template_publish(
     request: HttpRequest, organization_slug, odk_project_pk: int, form_template_id: int
 ):
     """Publish a FormTemplate to ODK Central."""
+    if request.method == "GET" and not (
+        (social_token := request.user.get_google_social_token()) and social_token.token_secret
+    ):
+        # The user does not have a Google refresh token. Send them through the
+        # OAuth consent flow again
+        logout(request)
+        messages.error(request, "Sorry, you need to log in again to be able to publish.")
+        querystring = urlencode({"auth_params": "prompt=select_account consent"})
+        login_url = f"{resolve_url(settings.LOGIN_URL)}?{querystring}"
+        return redirect_to_login(request.path, login_url, REDIRECT_FIELD_NAME)
+
     form_template: FormTemplate = get_object_or_404(
         request.odk_project.form_templates, pk=form_template_id
     )

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -8,7 +8,12 @@ class User(AbstractUser):
 
     def get_google_social_token(self) -> SocialToken | None:
         """Return the user's Google social token for use with the Google Sheets API."""
-        return SocialToken.objects.filter(account__user=self, account__provider="google").first()
+        # Prefer a SocialToken that has a token_secret (refresh token)
+        return (
+            SocialToken.objects.filter(account__user=self, account__provider="google")
+            .order_by("-token_secret")
+            .first()
+        )
 
     def get_organizations(self):
         from apps.publish_mdm.models import Organization

--- a/config/static/js/google_picker.js
+++ b/config/static/js/google_picker.js
@@ -40,7 +40,8 @@ function createPicker() {
           .setMode(google.picker.DocsViewMode.LIST)
           // Exclude Excel files stored in Google Drive (https://drive.google.com/file/... URLs)
           // which gspread won't be able to open (raises gspread.exceptions.NoValidUrlKeyFound)
-          .setMimeTypes("application/vnd.google-apps.spreadsheet"),
+          .setMimeTypes("application/vnd.google-apps.spreadsheet")
+          .setFileIds(googlePickerConfig.preselectedFileId || ""),
       )
       .enableFeature(google.picker.Feature.NAV_HIDDEN)
       .setOAuthToken(accessToken)
@@ -73,10 +74,14 @@ function createPicker() {
 // Callback called when the user selects a spreadsheet in the Google Picker dialog
 function pickerCallback(data) {
   if (data[google.picker.Response.ACTION] == google.picker.Action.PICKED) {
-    const doc = data[google.picker.Response.DOCUMENTS][0];
-    url = doc[google.picker.Document.URL];
-    document.querySelector(googlePickerConfig.urlInputSelector).value = url;
-    document.querySelector(googlePickerConfig.userInputSelector).value =
-      googlePickerConfig.user;
+    if (googlePickerConfig.filePickedCallback) {
+      googlePickerConfig.filePickedCallback();
+    } else {
+      const doc = data[google.picker.Response.DOCUMENTS][0];
+      url = doc[google.picker.Document.URL];
+      document.querySelector(googlePickerConfig.urlInputSelector).value = url;
+      document.querySelector(googlePickerConfig.userInputSelector).value =
+        googlePickerConfig.user;
+    }
   }
 }

--- a/config/templates/publish_mdm/ws/form_template_access_form.html
+++ b/config/templates/publish_mdm/ws/form_template_access_form.html
@@ -1,0 +1,45 @@
+{% load socialaccount %}
+{% load static %}
+<div id="form-access-error" class="mb-1">
+    <p class="mb-1">
+        Unfortunately, we could not access the form in Google Sheets. Click the button below to grant us access.
+    </p>
+    <button type="button"
+            class="btn btn-outline px-2 py-1"
+            onclick="createPicker()">Grant access</button>
+</div>
+{% get_social_accounts user as accounts %}
+{# Start Google Picker code #}
+<script>
+    let googlePickerConfig = {
+        accessToken: "{{ accounts.google.0.socialtoken_set.all.0.token }}",
+        clientId: "{{ google_client_id }}",
+        scopes: "{{ google_scopes }}",
+        apiKey: "{{ google_api_key }}",
+        appId: "{{ google_app_id }}",
+        preselectedFileId: "{{ google_sheet_id }}",
+        filePickedCallback: function() {
+            document.getElementById("form-access-error").innerHTML = `
+            <div class="alert flex items-center py-2 px-3 mb-2 rounded-lg text-primary-700 bg-primary-100 dark:bg-gray-800 dark:text-primary-300" role="alert">
+              <svg class="flex-shrink-0 w-4 h-4 dark:text-gray-300" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z" />
+              </svg>
+              <span class="sr-only">Success</span>
+              <div class="ms-3 text-sm font-medium">
+                You have successfully given us access to the file! Please try publishing again by clicking on the "Publish" button.
+              </div>
+            </div>`;
+        }
+    }
+</script>
+<script src="{% static 'js/google_picker.js' %}"></script>
+<!-- Load the Google API Loader script. -->
+<script async
+        defer
+        src="https://apis.google.com/js/api.js"
+        onload="onApiLoad()"></script>
+<script async
+        defer
+        src="https://accounts.google.com/gsi/client"
+        onload="gisLoaded()"></script>
+{# End Google Picker code #}

--- a/config/templates/publish_mdm/ws/message.html
+++ b/config/templates/publish_mdm/ws/message.html
@@ -2,8 +2,16 @@
     <div class="text-xs flex justify-end items-start p-3 {% if not error %}text-primary-700 bg-primary-100 dark:bg-gray-800 dark:text-primary-300{% else %} text-red-700 bg-red-50 dark:bg-gray-800 dark:text-red-400{% endif %}">
         {% now "n/j G:i:s.u" %}
     </div>
-    <div class="col-span-4 text-sm p-3 {% if complete %}font-bold{% endif %} {% if not error %}text-black dark:bg-gray-800 dark:text-primary-300{% else %} overflow-auto font-mono text-red-700 bg-red-50 dark:bg-gray-800 dark:text-red-400{% endif %}">
-        {% if error %}<pre class="text-xs">{% endif %}{{ message_text|escape }}{% if error %}</pre>
+    <div class="col-span-4 text-sm p-3 {% if complete %}font-bold{% endif %} {% if not error %}text-black dark:bg-gray-800 dark:text-primary-300{% else %} overflow-auto text-red-700 bg-red-50 dark:bg-gray-800 dark:text-red-400{% endif %}">
+        {% if error_summary %}
+            {{ error_summary }}
+            <details>
+                <summary class="cursor-pointer hover:underline">View the traceback</summary>
+                <pre class="text-xs font-mono mt-2">{{ message_text|escape }}</pre>
+            </details>
+        {% else %}
+            {% if error %}<pre class="text-xs font-mono">{% endif %}{{ message_text|escape }}{% if error %}</pre>
+            {% endif %}
         {% endif %}
         {% if complete or error %}<span x-data x-init="$store.publishing = false"></span>{% endif %}
     </div>

--- a/config/templates/socialaccount/snippets/login.html
+++ b/config/templates/socialaccount/snippets/login.html
@@ -10,6 +10,8 @@
     {% translate "Or use a third-party" %}
 {% endelement %}
 {% endif %}
-{% include "socialaccount/snippets/provider_list.html" with process="login" %}
+{% with auth_params=request.GET.auth_params %}
+    {% include "socialaccount/snippets/provider_list.html" with process="login" auth_params=auth_params %}
+{% endwith %}
 {% include "socialaccount/snippets/login_extra.html" %}
 {% endif %}

--- a/requirements/base/base.txt
+++ b/requirements/base/base.txt
@@ -6,7 +6,7 @@
 #
 aenum==3.1.16
     # via infisicalsdk
-alembic==1.16.2
+alembic==1.16.4
     # via dagster
 amqp==5.3.1
     # via kombu
@@ -20,7 +20,7 @@ anyio==3.7.1
     #   gql
     #   starlette
     #   watchfiles
-asgiref==3.8.1
+asgiref==3.9.1
     # via
     #   channels
     #   daphne
@@ -42,11 +42,11 @@ beautifulsoup4==4.13.4
     # via -r requirements/base/base.in
 billiard==4.2.1
     # via celery
-boto3==1.38.45
+boto3==1.40.2
     # via
     #   -r requirements/base/base.in
     #   infisicalsdk
-botocore==1.38.45
+botocore==1.40.2
     # via
     #   boto3
     #   infisicalsdk
@@ -58,14 +58,14 @@ celery==5.5.3
     #   -r requirements/base/base.in
     #   django-celery-beat
     #   django-structlog
-certifi==2025.6.15
+certifi==2025.8.3
     # via
     #   kubernetes
     #   requests
     #   sentry-sdk
 cffi==1.17.1
     # via cryptography
-channels==4.2.2
+channels==4.3.1
     # via -r requirements/base/base.in
 charset-normalizer==3.4.2
     # via requests
@@ -90,35 +90,35 @@ constantly==23.10.4
     # via twisted
 cron-descriptor==1.4.5
     # via django-celery-beat
-cryptography==45.0.4
+cryptography==45.0.5
     # via
     #   autobahn
     #   pyopenssl
     #   service-identity
-dagster==1.11.0
+dagster==1.11.4
     # via
     #   -r requirements/base/base.in
     #   dagster-graphql
     #   dagster-k8s
     #   dagster-postgres
     #   dagster-webserver
-dagster-graphql==1.11.0
+dagster-graphql==1.11.4
     # via dagster-webserver
-dagster-k8s==0.27.0
+dagster-k8s==0.27.4
     # via -r requirements/base/base.in
-dagster-pipes==1.11.0
+dagster-pipes==1.11.4
     # via dagster
-dagster-postgres==0.27.0
+dagster-postgres==0.27.4
     # via -r requirements/base/base.in
-dagster-shared==1.11.0
+dagster-shared==1.11.4
     # via dagster
-dagster-webserver==1.11.0
+dagster-webserver==1.11.4
     # via -r requirements/base/base.in
-daphne==4.2.0
+daphne==4.2.1
     # via -r requirements/base/base.in
 diff-match-patch==20241021
     # via django-import-export
-dj-database-url==3.0.0
+dj-database-url==3.0.1
     # via -r requirements/base/base.in
 django==5.2.2
     # via
@@ -137,7 +137,7 @@ django==5.2.2
     #   django-template-partials
     #   django-timezone-field
     #   slippers
-django-allauth==65.9.0
+django-allauth==65.10.0
     # via -r requirements/base/base.in
 django-celery-beat==2.8.1
     # via -r requirements/base/base.in
@@ -147,7 +147,7 @@ django-filter==25.1
     # via -r requirements/base/base.in
 django-htmx==1.23.2
     # via -r requirements/base/base.in
-django-import-export==4.3.8
+django-import-export==4.3.9
     # via -r requirements/base/base.in
 django-invitations==2.1.0
     # via -r requirements/base/base.in
@@ -165,7 +165,7 @@ django-timezone-field==7.1
     # via django-celery-beat
 django-widget-tweaks==1.5.0
     # via -r requirements/base/base.in
-docstring-parser==0.16
+docstring-parser==0.17.0
     # via dagster
 durationpy==0.10
     # via kubernetes
@@ -173,7 +173,7 @@ et-xmlfile==2.0.0
     # via openpyxl
 filelock==3.18.0
     # via dagster
-fsspec==2025.5.1
+fsspec==2025.7.0
     # via universal-pathlib
 google-auth==2.40.3
     # via
@@ -196,11 +196,11 @@ graphql-relay==3.2.0
     # via graphene
 greenlet==3.2.3
     # via sqlalchemy
-grpcio==1.73.1
+grpcio==1.74.0
     # via
     #   dagster
     #   grpcio-health-checking
-grpcio-health-checking==1.71.0
+grpcio-health-checking==1.71.2
     # via dagster
 gspread==6.2.1
     # via -r requirements/base/base.in
@@ -249,9 +249,9 @@ markupsafe==3.0.2
     #   mako
 mdurl==0.1.2
     # via markdown-it-py
-multidict==6.6.0
+multidict==6.6.3
     # via yarl
-newrelic==10.14.0
+newrelic==10.15.0
     # via -r requirements/base/base.in
 oauthlib==3.3.1
     # via
@@ -267,7 +267,7 @@ packaging==25.0
     #   dagster-shared
     #   gunicorn
     #   kombu
-pillow==11.2.1
+pillow==11.3.0
     # via -r requirements/base/base.in
 prompt-toolkit==3.0.51
     # via click-repl
@@ -310,7 +310,7 @@ pyopenssl==25.1.0
     # via twisted
 pyrate-limiter==2.10.0
     # via requests-ratelimiter
-python-crontab==3.2.0
+python-crontab==3.3.0
     # via django-celery-beat
 python-dateutil==2.9.0.post0
     # via
@@ -319,7 +319,6 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   infisicalsdk
     #   kubernetes
-    #   python-crontab
 python-dotenv==1.1.1
     # via
     #   -r requirements/base/base.in
@@ -358,15 +357,15 @@ requests-ratelimiter==0.7.0
     # via -r requirements/base/base.in
 requests-toolbelt==1.0.0
     # via gql
-rich==14.0.0
+rich==14.1.0
     # via dagster
 rsa==4.9.1
     # via google-auth
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via boto3
 segno==1.6.6
     # via -r requirements/base/base.in
-sentry-sdk==2.32.0
+sentry-sdk==2.34.1
     # via -r requirements/base/base.in
 service-identity==24.2.0
     # via twisted
@@ -381,13 +380,13 @@ sniffio==1.3.1
     # via anyio
 soupsieve==2.7
     # via beautifulsoup4
-sqlalchemy==2.0.41
+sqlalchemy==2.0.42
     # via
     #   alembic
     #   dagster
 sqlparse==0.5.3
     # via django
-starlette==0.47.1
+starlette==0.47.2
     # via
     #   dagster-graphql
     #   dagster-webserver
@@ -415,12 +414,11 @@ txaio==25.6.1
     # via autobahn
 typeguard==2.13.3
     # via slippers
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   alembic
     #   beautifulsoup4
     #   dagster-shared
-    #   dj-database-url
     #   graphene
     #   psycopg
     #   pydantic
@@ -442,7 +440,7 @@ urllib3==2.5.0
     #   kubernetes
     #   requests
     #   sentry-sdk
-uvicorn==0.34.3
+uvicorn==0.35.0
     # via dagster-webserver
 uvloop==0.21.0
     # via uvicorn

--- a/requirements/dev/dev.in
+++ b/requirements/dev/dev.in
@@ -10,6 +10,7 @@ factory-boy
 jupyterlab
 pre-commit
 pytest
+pytest-asyncio
 pytest-cov
 pytest-django
 pytest-mock

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -12,11 +12,11 @@ anyio==3.7.1
     #   watchfiles
 argon2-cffi==25.1.0
     # via jupyter-server
-argon2-cffi-bindings==21.2.0
+argon2-cffi-bindings==25.1.0
     # via argon2-cffi
 arrow==1.3.0
     # via isoduration
-asgiref==3.8.1
+asgiref==3.9.1
     # via
     #   -c requirements/dev/../base/base.txt
     #   django
@@ -40,17 +40,17 @@ black==25.1.0
     # via -r requirements/dev/dev.in
 bleach==6.2.0
     # via nbconvert
-boto3==1.38.45
+boto3==1.40.2
     # via
     #   -c requirements/dev/../base/base.txt
     #   moto
-botocore==1.38.45
+botocore==1.40.2
     # via
     #   -c requirements/dev/../base/base.txt
     #   boto3
     #   moto
     #   s3transfer
-certifi==2025.6.15
+certifi==2025.8.3
     # via
     #   -c requirements/dev/../base/base.txt
     #   httpcore
@@ -74,23 +74,23 @@ click==8.1.8
     #   djlint
 colorama==0.4.6
     # via djlint
-comm==0.2.2
+comm==0.2.3
     # via ipykernel
-coverage==7.9.1
+coverage==7.10.2
     # via pytest-cov
-cryptography==45.0.4
+cryptography==45.0.5
     # via
     #   -c requirements/dev/../base/base.txt
     #   moto
 cssbeautifier==1.15.4
     # via djlint
-debugpy==1.8.14
+debugpy==1.8.15
     # via ipykernel
 decorator==5.2.1
     # via ipython
 defusedxml==0.7.1
     # via nbconvert
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
 django==5.2.2
     # via
@@ -100,9 +100,9 @@ django==5.2.2
     #   django-watchfiles
 django-browser-reload==1.18.0
     # via -r requirements/dev/dev.in
-django-debug-toolbar==5.2.0
+django-debug-toolbar==6.0.0
     # via -r requirements/dev/dev.in
-django-types==0.21.0
+django-types==0.22.0
     # via -r requirements/dev/dev.in
 django-watchfiles==1.1.0
     # via -r requirements/dev/dev.in
@@ -116,7 +116,7 @@ executing==2.2.0
     # via stack-data
 factory-boy==3.3.3
     # via -r requirements/dev/dev.in
-faker==37.4.0
+faker==37.5.3
     # via factory-boy
 fastjsonschema==2.21.1
     # via nbformat
@@ -145,9 +145,9 @@ idna==3.10
     #   requests
 iniconfig==2.1.0
     # via pytest
-ipykernel==6.29.5
+ipykernel==6.30.1
     # via jupyterlab
-ipython==9.3.0
+ipython==9.4.0
     # via ipykernel
 ipython-pygments-lexers==1.1.1
     # via ipython
@@ -178,7 +178,7 @@ json5==0.12.0
     #   jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
-jsonschema==4.24.0
+jsonschema==4.25.0
     # via
     #   jupyter-events
     #   jupyterlab-server
@@ -201,7 +201,7 @@ jupyter-core==5.8.1
     #   nbformat
 jupyter-events==0.12.0
     # via jupyter-server
-jupyter-lsp==2.2.5
+jupyter-lsp==2.2.6
     # via jupyterlab
 jupyter-server==2.16.0
     # via
@@ -211,12 +211,14 @@ jupyter-server==2.16.0
     #   notebook-shim
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.4.3
+jupyterlab==4.4.5
     # via -r requirements/dev/dev.in
 jupyterlab-pygments==0.3.0
     # via nbconvert
 jupyterlab-server==2.27.3
     # via jupyterlab
+lark==1.2.2
+    # via rfc3987-syntax
 markupsafe==3.0.2
     # via
     #   -c requirements/dev/../base/base.txt
@@ -229,7 +231,7 @@ matplotlib-inline==0.1.7
     #   ipython
 mistune==3.1.3
     # via nbconvert
-moto==5.1.6
+moto==5.1.9
     # via -r requirements/dev/dev.in
 mypy-extensions==1.1.0
     # via black
@@ -312,9 +314,12 @@ pygments==2.19.2
 pytest==8.4.1
     # via
     #   -r requirements/dev/dev.in
+    #   pytest-asyncio
     #   pytest-cov
     #   pytest-django
     #   pytest-mock
+pytest-asyncio==1.1.0
+    # via -r requirements/dev/dev.in
 pytest-cov==6.2.1
     # via -r requirements/dev/dev.in
 pytest-django==4.11.1
@@ -338,7 +343,7 @@ pyyaml==6.0.2
     #   moto
     #   pre-commit
     #   responses
-pyzmq==27.0.0
+pyzmq==27.0.1
     # via
     #   ipykernel
     #   jupyter-client
@@ -348,7 +353,7 @@ referencing==0.36.2
     #   jsonschema
     #   jsonschema-specifications
     #   jupyter-events
-regex==2024.11.6
+regex==2025.7.34
     # via djlint
 requests==2.32.3
     # via
@@ -369,11 +374,13 @@ rfc3986-validator==0.1.1
     # via
     #   jsonschema
     #   jupyter-events
-rpds-py==0.25.1
+rfc3987-syntax==1.1.0
+    # via jsonschema
+rpds-py==0.26.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via
     #   -c requirements/dev/../base/base.txt
     #   boto3
@@ -420,7 +427,6 @@ tqdm==4.67.1
     #   djlint
 traitlets==5.14.3
     # via
-    #   comm
     #   ipykernel
     #   ipython
     #   jupyter-client
@@ -432,11 +438,11 @@ traitlets==5.14.3
     #   nbclient
     #   nbconvert
     #   nbformat
-types-psycopg2==2.9.21.20250516
+types-psycopg2==2.9.21.20250718
     # via django-types
-types-python-dateutil==2.9.0.20250516
+types-python-dateutil==2.9.0.20250708
     # via arrow
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   -c requirements/dev/../base/base.txt
     #   beautifulsoup4
@@ -453,7 +459,7 @@ urllib3==2.5.0
     #   botocore
     #   requests
     #   responses
-virtualenv==20.31.2
+virtualenv==20.33.0
     # via pre-commit
 watchfiles==1.1.0
     # via

--- a/tests/publish_mdm/etl/extract/test_google.py
+++ b/tests/publish_mdm/etl/extract/test_google.py
@@ -47,32 +47,20 @@ class TestDownloadUserGoogleSheet:
         """Test the download of a user Google Sheet from a FormTemplate."""
         user = UserFactory.build()
         token = SocialTokenFactory.build(token="token", token_secret="token_secret")
-        form_template = FormTemplateFactory.build(
-            form_id_base="staff_registration", template_url_user=user
-        )
+        form_template = FormTemplateFactory.build(form_id_base="staff_registration")
         mocker.patch.object(user, "get_google_social_token", return_value=token)
         mock_gspread_client = mocker.patch("apps.publish_mdm.etl.google.gspread_client")
         mock_gspread_client.return_value.open_by_url.return_value.export.return_value = (
             b"file content"
         )
-        downloaded_file = form_template.download_user_google_sheet(name="mysheet.xlsx")
+        downloaded_file = form_template.download_user_google_sheet(user=user, name="mysheet.xlsx")
         assert downloaded_file.name == "mysheet.xlsx"
         assert downloaded_file.read() == b"file content"
 
     def test_form_template_download_user_google_sheet_no_token(self, mocker):
         """Test error raised if user has no Google token."""
         user = UserFactory.build()
-        form_template = FormTemplateFactory.build(
-            form_id_base="staff_registration", template_url_user=user
-        )
-        mocker.patch.object(user, "get_google_social_token", return_value=None)
-        with pytest.raises(ValueError, match="User does not have a Google social token."):
-            form_template.download_user_google_sheet(name="mysheet.xlsx")
-
-    def test_form_template_download_user_google_sheet_no_template_url_user(self, mocker):
-        """Test error raised if FormTemplate.template_url_user is not set."""
         form_template = FormTemplateFactory.build(form_id_base="staff_registration")
-        with pytest.raises(
-            ValueError, match="The user who gave access to the Google Sheet is not known."
-        ):
-            form_template.download_user_google_sheet(name="mysheet.xlsx")
+        mocker.patch.object(user, "get_google_social_token", return_value=None)
+        with pytest.raises(ValueError):
+            form_template.download_user_google_sheet(user=user, name="mysheet.xlsx")

--- a/tests/publish_mdm/etl/load/test_publish.py
+++ b/tests/publish_mdm/etl/load/test_publish.py
@@ -67,9 +67,7 @@ class TestPublishFormTemplate:
         )
         project = ProjectFactory(central_server__base_url="https://central", central_id=2)
         user = UserFactory()
-        form_template = FormTemplateFactory(
-            project=project, form_id_base="staff_registration", template_url_user=user
-        )
+        form_template = FormTemplateFactory(project=project, form_id_base="staff_registration")
         # Create 2 app users
         user_form1 = AppUserFormTemplateFactory(form_template=form_template, app_user__name="user1")
         user_form2 = AppUserFormTemplateFactory(form_template=form_template, app_user__name="user2")

--- a/tests/publish_mdm/test_consumer.py
+++ b/tests/publish_mdm/test_consumer.py
@@ -1,0 +1,61 @@
+import pytest
+from channels.testing import WebsocketCommunicator
+from gspread.exceptions import SpreadsheetNotFound
+from pytest_django.asserts import assertTemplateUsed
+
+from apps.publish_mdm.consumers import PublishTemplateConsumer
+from tests.publish_mdm.factories import FormTemplateFactory
+from tests.users.factories import UserFactory
+
+
+class TestPublishTemplateConsumer:
+    """Tests for PublishTemplateConsumer."""
+
+    @pytest.mark.asyncio
+    async def test_google_access_error(self, mocker):
+        """Ensures get_google_picker() is called if we get a SpreadsheetNotFound
+        exception when publishing. The exception is raised by gspread if a user
+        has not given us permission to access a file using their Google credentials.
+        """
+        communicator = WebsocketCommunicator(
+            PublishTemplateConsumer.as_asgi(), "/ws/publish-template/"
+        )
+        connected, subprotocol = await communicator.connect()
+        assert connected
+        mocker.patch.object(
+            PublishTemplateConsumer, "publish_form_template", side_effect=SpreadsheetNotFound()
+        )
+        google_picker = "google picker html"
+        mock_get_google_picker = mocker.patch.object(
+            PublishTemplateConsumer, "get_google_picker", return_value=google_picker
+        )
+        form_template_id = 1
+
+        await communicator.send_json_to({"form_template": form_template_id, "app_users": ""})
+        with assertTemplateUsed("publish_mdm/ws/message.html") as cm:
+            await communicator.receive_from()
+
+        assert cm.context.get("error")
+        assert cm.context.get("message_text", "").startswith("Traceback (most recent call last)")
+        mock_get_google_picker.assert_called_with(form_template_id=form_template_id)
+        assert cm.context.get("error_summary") == google_picker
+        await communicator.disconnect()
+
+    @pytest.mark.django_db
+    def test_get_google_picker(self):
+        """Tests the get_google_picker method."""
+        google_sheet_id = "test123"
+        form_template = FormTemplateFactory(
+            template_url=f"https://docs.google.com/spreadsheets/d/{google_sheet_id}/edit?usp=drive_web"
+        )
+        consumer = PublishTemplateConsumer()
+        consumer.scope = {"user": UserFactory()}
+        with assertTemplateUsed(
+            template_name="publish_mdm/ws/form_template_access_form.html"
+        ) as cm:
+            result = consumer.get_google_picker(form_template.id)
+        assert cm.context.get("google_sheet_id") == google_sheet_id
+        assert (
+            "Unfortunately, we could not access the form in Google Sheets. "
+            "Click the button below to grant us access."
+        ) in result

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -58,3 +58,5 @@ class SocialTokenFactory(factory.django.DjangoModelFactory):
         model = SocialToken
 
     account = factory.SubFactory(SocialAccountFactory)
+    token = factory.Faker("pystr")
+    token_secret = factory.Faker("pystr")


### PR DESCRIPTION
This PR updates the publishing process to use the currently logged-in user's credentials to download the file from Google Sheets, instead of using the credentials of `FormTemplate.template_url_user` (the user who added or edited the `template_url`). If a user has no refresh token and they try to access the Publish page, they will be redirected to the login page, for them to go through the OAuth flow again.