### PR TITLE
Show masked usernames in the Central Servers list page.

### DIFF
--- a/apps/infisical/managers.py
+++ b/apps/infisical/managers.py
@@ -21,7 +21,7 @@ class EncryptedQuery(models.sql.Query):
                 # It defaults to model.TextField(), which doesn't decrypt.
                 updated_ret = []
                 for col, (sql, params), alias in ret:
-                    if isinstance(col.target, EncryptedMixin):
+                    if hasattr(col, "target") and isinstance(col.target, EncryptedMixin):
                         col = col.target.get_col(col.alias, output_field=col.target)
                     updated_ret.append((col, (sql, params), alias))
                 return updated_ret, klass_info, annotations

--- a/apps/publish_mdm/models.py
+++ b/apps/publish_mdm/models.py
@@ -109,6 +109,17 @@ class CentralServer(AbstractBaseModel):
                 value = kms_api.decrypt("centralserver", value)
                 setattr(self, field, value)
 
+    @property
+    def masked_username(self):
+        """If a username is set, partially hide it."""
+        if self.username:
+            mask = "*" * 5
+            if "@" in self.username:
+                name, rest = self.username.split("@", 1)
+                return f"{name[0]}{mask}@{rest}"
+            return f"{self.username[0]}{mask}"
+        return self.username
+
 
 class TemplateVariable(AbstractBaseModel):
     """A variable that can be used in a FormTemplate."""

--- a/apps/publish_mdm/tables.py
+++ b/apps/publish_mdm/tables.py
@@ -52,10 +52,11 @@ class CentralServerTable(tables.Table):
         args=[tables.A("organization__slug"), tables.A("pk")],
         attrs={"a": {"class": "text-primary-600 hover:underline"}},
     )
+    username = tables.Column(accessor="masked_username")
 
     class Meta:
         model = CentralServer
-        fields = ["base_url", "created_at"]
+        fields = ["base_url", "username", "created_at"]
         template_name = "patterns/tables/table.html"
         attrs = {"th": {"scope": "col", "class": "px-4 py-3 whitespace-nowrap"}}
         orderable = False

--- a/apps/publish_mdm/views.py
+++ b/apps/publish_mdm/views.py
@@ -751,7 +751,9 @@ def organization_template_variables(request, organization_slug):
 @login_required
 def central_servers_list(request: HttpRequest, organization_slug):
     """List CentralServers linked to the current organization."""
-    central_servers = request.organization.central_servers.order_by("-created_at")
+    central_servers = CentralServer.decrypted.filter(organization=request.organization).order_by(
+        "-created_at"
+    )
     table = CentralServerTable(data=central_servers, request=request, show_footer=False)
     context = {
         "table": table,

--- a/tests/publish_mdm/test_models.py
+++ b/tests/publish_mdm/test_models.py
@@ -93,6 +93,13 @@ class TestCentralServer:
         assert server.password == ""
         mock_decrypt.assert_not_called()
 
+    @pytest.mark.parametrize("username", ["test@example.com", "test", ""])
+    def test_masked_username(self, mocker, username):
+        mocker.patch.object(InfisicalKMS, "decrypt", return_value=username)
+        server = CentralServerFactory(username=username, password="")
+        server = CentralServer.decrypted.get(id=server.id)
+        assert server.masked_username == username.replace("test", "t*****")
+
 
 class TestTemplateVariable:
     def test_str(self):

--- a/tests/publish_mdm/test_views.py
+++ b/tests/publish_mdm/test_views.py
@@ -1848,10 +1848,11 @@ class TestCentralServerList(ViewTestBase):
         table = response.context.get("table")
         assert isinstance(table, Table)
         rows = response.context["table"].as_values()
-        assert next(rows) == ["Base URL", "Created at"]
+        assert next(rows) == ["Base URL", "Username", "Created at"]
         assert list(rows) == [
             [
                 i.base_url,
+                i.masked_username,
                 date_format(localtime(i.created_at), settings.SHORT_DATETIME_FORMAT),
             ]
             for i in organization.central_servers.order_by("-created_at")


### PR DESCRIPTION
This PR adds a "Username" column in the Central Servers list page, which shows partially hidden usernames to enable easy identification if multiple Central Servers have the same "Base URL".