### PR TITLE
Set admin_pw correctly in app user QR codes.

### DIFF
--- a/apps/publish_mdm/etl/odk/qrcode.py
+++ b/apps/publish_mdm/etl/odk/qrcode.py
@@ -27,7 +27,7 @@ def build_collect_settings(
     collect_settings = DEFAULT_COLLECT_SETTINGS.copy()
 
     if admin_pw:
-        collect_settings.setdefault("admin_pw", {})["admin_pw"] = str(admin_pw)
+        collect_settings["admin"]["admin_pw"] = admin_pw
 
     # Customize settings
     url = f"{base_url.rstrip("/")}/key/{app_user.token}/projects/{project_id}"
@@ -49,8 +49,6 @@ def create_app_user_qrcode(
     language: str = "en",
 ) -> tuple[io.BytesIO, dict]:
     """Generate a QR code as a PNG for the given app user."""
-
-    admin_pw = str(admin_pw) if admin_pw else ""
 
     # Build app user settings
     collect_settings = build_collect_settings(

--- a/tests/publish_mdm/etl/odk/test_qrcode.py
+++ b/tests/publish_mdm/etl/odk/test_qrcode.py
@@ -50,6 +50,7 @@ class TestCollectSettings:
 
         assert qr_code.getvalue()[:4] == b"\x89PNG"
         assert collect_settings == build_collect_settings(**kwargs)
+        assert collect_settings["admin"]["admin_pw"] == kwargs["admin_pw"]
 
     @pytest.mark.django_db
     @pytest.mark.parametrize("app_language", ["", "ar"])


### PR DESCRIPTION
This PR fixes how the `admin_pw` is set in app user QR codes, ensuring the password is required to change project settings in Collect.